### PR TITLE
Add Tauri React scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # OptiPlatform
+
+This repository contains a basic Tauri + React application scaffolded with Vite and TypeScript.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+To run the Tauri application (requires Rust toolchain):
+
+```bash
+npm run tauri dev
+```
+
+## Project Structure
+
+- `src-tauri/` - Tauri backend source code and configuration
+- `src/` - React frontend source code
+
+The React application features a simple sidebar layout and a dashboard page using React Router.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OptiPlatform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "optiplatform",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "tauri": "tauri dev"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.17.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@tauri-apps/cli": "^2.0.0"
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "optiplatform"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "^2.0.0-beta.17" }
+
+[build-dependencies]
+
+[dev-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "package": {
+    "productName": "OptiPlatform",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "targets": ["deb"]
+    },
+    "windows": [
+      {
+        "title": "OptiPlatform",
+        "width": 800,
+        "height": 600
+      }
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import { Route, Routes, Navigate } from 'react-router-dom';
+import MainLayout from './layout/MainLayout';
+import Dashboard from './pages/Dashboard';
+
+function App() {
+  return (
+    <MainLayout>
+      <Routes>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </MainLayout>
+  );
+}
+
+export default App;

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,0 +1,11 @@
+.sidebar {
+  width: 200px;
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+
+.logo {
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,15 @@
+import { NavLink } from 'react-router-dom';
+import './Sidebar.css';
+
+export default function Sidebar() {
+  return (
+    <nav className="sidebar">
+      <h2 className="logo">OptiPlatform</h2>
+      <ul>
+        <li>
+          <NavLink to="/dashboard">Dashboard</NavLink>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+}
+
+nav a {
+  text-decoration: none;
+  color: black;
+}
+
+nav a.active {
+  font-weight: bold;
+}

--- a/src/layout/MainLayout.css
+++ b/src/layout/MainLayout.css
@@ -1,0 +1,9 @@
+.layout {
+  display: flex;
+  height: 100vh;
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
+}

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import Sidebar from '../components/Sidebar';
+import './MainLayout.css';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function MainLayout({ children }: Props) {
+  return (
+    <div className="layout">
+      <Sidebar />
+      <main className="content">{children}</main>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <h1>Dashboard</h1>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a React + Tauri project created with Vite
- set up React Router and sidebar layout
- add minimal Tauri backend

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684823e1d5b083228776406ac4b166a1