### PR TITLE
Add NestJS backend boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This repository contains a basic Tauri + React application scaffolded with Vite and TypeScript.
 
+## Backend
+
+The `server` directory holds a NestJS API with GraphQL, PostgreSQL via TypeORM
+and simple JWT authentication.
+
+Install dependencies and run the server:
+
+```bash
+cd server
+npm install
+npm run start:dev
+```
+
 ## Development
 
 Install dependencies and start the development server:
@@ -21,5 +34,6 @@ npm run tauri dev
 
 - `src-tauri/` - Tauri backend source code and configuration
 - `src/` - React frontend source code
+- `server/` - NestJS GraphQL API
 
 The React application features a simple sidebar layout and a dashboard page using React Router.

--- a/server/nest-cli.json
+++ b/server/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "nest-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/graphql": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "graphql": "^16.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.5.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.0",
+    "typeorm": "^0.3.0",
+    "pg": "^8.0.0",
+    "bcrypt": "^5.0.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { join } from 'path';
+import { AuthModule } from './auth/auth.module';
+import { AppResolver } from './app.resolver';
+import { User } from './user/user.entity';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({
+      autoSchemaFile: join(process.cwd(), 'schema.gql'),
+    }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'mydb',
+      entities: [User],
+      synchronize: true,
+    }),
+    AuthModule,
+    TypeOrmModule.forFeature([User]),
+  ],
+  providers: [AppResolver],
+})
+export class AppModule {}

--- a/server/src/app.resolver.ts
+++ b/server/src/app.resolver.ts
@@ -1,0 +1,9 @@
+import { Resolver, Query } from '@nestjs/graphql';
+
+@Resolver()
+export class AppResolver {
+  @Query(() => String)
+  hello(): string {
+    return 'Hello World!';
+  }
+}

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './jwt.strategy';
+import { AuthResolver } from './auth.resolver';
+
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.register({
+      secret: 'secretKey',
+      signOptions: { expiresIn: '60m' },
+    }),
+  ],
+  providers: [AuthService, JwtStrategy, AuthResolver],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/server/src/auth/auth.resolver.ts
+++ b/server/src/auth/auth.resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { AuthService } from './auth.service';
+import { LoginInput } from './dto/login.input';
+
+@Resolver()
+export class AuthResolver {
+  constructor(private readonly authService: AuthService) {}
+
+  @Mutation(() => String)
+  async login(@Args('data') loginInput: LoginInput) {
+    const user = await this.authService.validateUser(
+      loginInput.username,
+      loginInput.password,
+    );
+    if (!user) {
+      throw new Error('Invalid credentials');
+    }
+    return this.authService.login(user);
+  }
+}

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async validateUser(username: string, pass: string): Promise<any> {
+    // Placeholder validation logic
+    const user = { id: 1, username: 'test', password: await bcrypt.hash('test', 10) };
+    const isMatch = await bcrypt.compare(pass, user.password);
+    if (username === user.username && isMatch) {
+      const { password, ...result } = user;
+      return result;
+    }
+    return null;
+  }
+
+  async login(user: any) {
+    const payload = { username: user.username, sub: user.id };
+    return this.jwtService.sign(payload);
+  }
+}

--- a/server/src/auth/dto/login.input.ts
+++ b/server/src/auth/dto/login.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class LoginInput {
+  @Field()
+  username: string;
+
+  @Field()
+  password: string;
+}

--- a/server/src/auth/jwt.strategy.ts
+++ b/server/src/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: 'secretKey',
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, username: payload.username };
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  username: string;
+
+  @Column()
+  password: string;
+}

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2018",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a NestJS GraphQL backend with TypeORM and JWT auth
- document new server directory in README

## Testing
- `npx tsc -p server/tsconfig.json` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_684825193c90832297cdeeae6a1f884d