### PR TITLE
Add OAuth login with secure token storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.17.0"
+    "react-router-dom": "^6.17.0",
+    "@tauri-apps/plugin-store": "^2.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
+import type { Response } from 'express';
 
 @Controller('auth')
 export class AuthController {
@@ -14,8 +15,9 @@ export class AuthController {
 
   @Get('google/redirect')
   @UseGuards(AuthGuard('google'))
-  async googleAuthRedirect(@Req() req) {
-    return this.authService.oauthLogin(req.user);
+  async googleAuthRedirect(@Req() req, @Res() res: Response) {
+    const token = await this.authService.oauthLogin(req.user);
+    res.send(`<script>window.opener.postMessage({ token: '${token}' }, '*');window.close();</script>`);
   }
 
   @Get('github')
@@ -26,7 +28,8 @@ export class AuthController {
 
   @Get('github/redirect')
   @UseGuards(AuthGuard('github'))
-  async githubAuthRedirect(@Req() req) {
-    return this.authService.oauthLogin(req.user);
+  async githubAuthRedirect(@Req() req, @Res() res: Response) {
+    const token = await this.authService.oauthLogin(req.user);
+    res.send(`<script>window.opener.postMessage({ token: '${token}' }, '*');window.close();</script>`);
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 tauri = { version = "^2.0.0-beta.17" }
+tauri-plugin-store = "2.0.0"
 
 [build-dependencies]
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use tauri_plugin_store::Builder as StoreBuilder;
+
 fn main() {
     tauri::Builder::default()
+        .plugin(StoreBuilder::default().build())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
 import { Route, Routes, Navigate } from 'react-router-dom';
 import MainLayout from './layout/MainLayout';
 import Dashboard from './pages/Dashboard';
+import Login from './pages/Login';
 
 function App() {
   return (
-    <MainLayout>
-      <Routes>
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route element={<MainLayout />}>
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/dashboard" element={<Dashboard />} />
-      </Routes>
-    </MainLayout>
+      </Route>
+    </Routes>
   );
 }
 

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,16 +1,14 @@
-import { ReactNode } from 'react';
+import { Outlet } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
 import './MainLayout.css';
 
-interface Props {
-  children: ReactNode;
-}
-
-export default function MainLayout({ children }: Props) {
+export default function MainLayout() {
   return (
     <div className="layout">
       <Sidebar />
-      <main className="content">{children}</main>
+      <main className="content">
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { saveToken } from '../utils/authStore';
+
+export default function Login() {
+  useEffect(() => {
+    const handler = async (e: MessageEvent) => {
+      if (e.data && e.data.token) {
+        await saveToken(e.data.token);
+        window.location.assign('/dashboard');
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  const openOAuth = (provider: 'google' | 'github') => {
+    const w = 500;
+    const h = 600;
+    const y = window.top ? (window.outerHeight - h) / 2 : 0;
+    const x = window.top ? (window.outerWidth - w) / 2 : 0;
+    window.open(
+      `http://localhost:3001/auth/${provider}`,
+      'oauth',
+      `width=${w},height=${h},left=${x},top=${y}`
+    );
+  };
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <button onClick={() => openOAuth('google')}>Login with Google</button>
+      <button onClick={() => openOAuth('github')}>Login with GitHub</button>
+    </div>
+  );
+}

--- a/src/utils/authStore.ts
+++ b/src/utils/authStore.ts
@@ -1,0 +1,13 @@
+import { LazyStore } from '@tauri-apps/plugin-store';
+
+const store = new LazyStore('auth.json');
+
+export async function saveToken(token: string) {
+  await store.set('jwt', token);
+  await store.save();
+}
+
+export async function getToken(): Promise<string | null> {
+  const val = await store.get<string>('jwt');
+  return val ?? null;
+}


### PR DESCRIPTION
## Summary
- add OAuth redirect handling in Nest controller
- enable Tauri store plugin for secure storage
- add React store utility for saving JWT
- create Login page with OAuth buttons
- switch layout to use outlet and update routing

## Testing
- `npm run build` *(fails: vite not found)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 dev libs missing)*

------
https://chatgpt.com/codex/tasks/task_e_68482a936f748322b6d3b6e60bd523ed