### PR TITLE
Add Hasura and inventory schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ npm run tauri dev
 - `server/` - NestJS GraphQL API
 
 The React application features a simple sidebar layout and a dashboard page using React Router.
+
+## Database and Hasura
+
+A `docker-compose.yml` configuration is included to launch PostgreSQL along with Hasura. The schema for the inventory system resides in `database/schema.sql` and defines tables for `users`, `products`, `locations` and `inventory_transactions`.
+
+Start both services with:
+
+```bash
+docker-compose up -d
+```
+
+Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT secret as the NestJS backend (`secretKey`).

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  password TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS locations (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  address TEXT
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  unit TEXT
+);
+
+CREATE TABLE IF NOT EXISTS inventory_transactions (
+  id SERIAL PRIMARY KEY,
+  product_id INTEGER REFERENCES products(id) ON DELETE CASCADE,
+  location_id INTEGER REFERENCES locations(id) ON DELETE CASCADE,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  quantity INTEGER NOT NULL,
+  transaction_type TEXT NOT NULL,
+  occurred_at TIMESTAMP DEFAULT NOW()
+);
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.6'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mydb
+    volumes:
+      - ./database/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    ports:
+      - "5432:5432"
+
+  hasura:
+    image: hasura/graphql-engine:v2.36.2
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgres@db:5432/mydb
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
+      HASURA_GRAPHQL_JWT_SECRET: '{"type":"HS256","key":"secretKey"}'
+


### PR DESCRIPTION
## Summary
- create a database schema for users, products, locations and inventory_transactions
- provide docker-compose for PostgreSQL and Hasura using the NestJS JWT secret
- document how to run Hasura and the schema

## Testing
- `npm run build`
- `cd server && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68482aa7024c83229b9d54ada87c3ec1