### PR TITLE
Add inventory GraphQL module and UI components

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,9 @@ import { join } from 'path';
 import { AuthModule } from './auth/auth.module';
 import { AppResolver } from './app.resolver';
 import { User } from './user/user.entity';
+import { InventoryModule } from './inventory/inventory.module';
+import { Product } from './inventory/entities/product.entity';
+import { InventoryTransaction } from './inventory/entities/inventory-transaction.entity';
 
 @Module({
   imports: [
@@ -18,11 +21,12 @@ import { User } from './user/user.entity';
       username: 'postgres',
       password: 'postgres',
       database: 'mydb',
-      entities: [User],
+      entities: [User, Product, InventoryTransaction],
       synchronize: true,
     }),
     AuthModule,
-    TypeOrmModule.forFeature([User]),
+    InventoryModule,
+    TypeOrmModule.forFeature([User, Product, InventoryTransaction]),
   ],
   providers: [AppResolver],
 })

--- a/server/src/inventory/dto/create-inventory-transaction.input.ts
+++ b/server/src/inventory/dto/create-inventory-transaction.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+
+@InputType()
+export class CreateInventoryTransactionInput {
+  @Field(() => Int)
+  productId: number;
+
+  @Field(() => Int)
+  quantity: number;
+
+  @Field()
+  transactionType: string;
+}

--- a/server/src/inventory/dto/create-product.input.ts
+++ b/server/src/inventory/dto/create-product.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class CreateProductInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  unit?: string;
+}

--- a/server/src/inventory/dto/update-inventory-transaction.input.ts
+++ b/server/src/inventory/dto/update-inventory-transaction.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, Int, PartialType } from '@nestjs/graphql';
+import { CreateInventoryTransactionInput } from './create-inventory-transaction.input';
+
+@InputType()
+export class UpdateInventoryTransactionInput extends PartialType(CreateInventoryTransactionInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/server/src/inventory/dto/update-product.input.ts
+++ b/server/src/inventory/dto/update-product.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, Int, PartialType } from '@nestjs/graphql';
+import { CreateProductInput } from './create-product.input';
+
+@InputType()
+export class UpdateProductInput extends PartialType(CreateProductInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/server/src/inventory/entities/inventory-transaction.entity.ts
+++ b/server/src/inventory/entities/inventory-transaction.entity.ts
@@ -1,0 +1,31 @@
+import { Field, ObjectType, Int } from '@nestjs/graphql';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Product } from './product.entity';
+
+@ObjectType()
+@Entity({ name: 'inventory_transactions' })
+export class InventoryTransaction {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field(() => Int)
+  @Column()
+  productId: number;
+
+  @Field(() => Int)
+  @Column()
+  quantity: number;
+
+  @Field()
+  @Column()
+  transactionType: string;
+
+  @Field()
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  occurredAt: Date;
+
+  @ManyToOne(() => Product)
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+}

--- a/server/src/inventory/entities/product.entity.ts
+++ b/server/src/inventory/entities/product.entity.ts
@@ -1,0 +1,22 @@
+import { Field, ObjectType, Int } from '@nestjs/graphql';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@ObjectType()
+@Entity({ name: 'products' })
+export class Product {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column()
+  name: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  unit?: string;
+}

--- a/server/src/inventory/inventory-transaction.resolver.ts
+++ b/server/src/inventory/inventory-transaction.resolver.ts
@@ -1,0 +1,35 @@
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { InventoryService } from './inventory.service';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
+import { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.input';
+import { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.input';
+
+@Resolver(() => InventoryTransaction)
+export class InventoryTransactionResolver {
+  constructor(private readonly service: InventoryService) {}
+
+  @Mutation(() => InventoryTransaction)
+  createTransaction(@Args('data') data: CreateInventoryTransactionInput) {
+    return this.service.createTransaction(data);
+  }
+
+  @Mutation(() => InventoryTransaction)
+  updateTransaction(@Args('data') data: UpdateInventoryTransactionInput) {
+    return this.service.updateTransaction(data);
+  }
+
+  @Mutation(() => Boolean)
+  removeTransaction(@Args('id', { type: () => Int }) id: number) {
+    return this.service.removeTransaction(id).then(() => true);
+  }
+
+  @Query(() => [InventoryTransaction])
+  transactions() {
+    return this.service.findAllTransactions();
+  }
+
+  @Query(() => InventoryTransaction, { nullable: true })
+  transaction(@Args('id', { type: () => Int }) id: number) {
+    return this.service.findTransaction(id);
+  }
+}

--- a/server/src/inventory/inventory.module.ts
+++ b/server/src/inventory/inventory.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InventoryService } from './inventory.service';
+import { Product } from './entities/product.entity';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
+import { ProductResolver } from './product.resolver';
+import { InventoryTransactionResolver } from './inventory-transaction.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product, InventoryTransaction])],
+  providers: [InventoryService, ProductResolver, InventoryTransactionResolver],
+})
+export class InventoryModule {}

--- a/server/src/inventory/inventory.service.ts
+++ b/server/src/inventory/inventory.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product } from './entities/product.entity';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
+import { CreateProductInput } from './dto/create-product.input';
+import { UpdateProductInput } from './dto/update-product.input';
+import { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.input';
+import { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.input';
+
+@Injectable()
+export class InventoryService {
+  constructor(
+    @InjectRepository(Product)
+    private products: Repository<Product>,
+    @InjectRepository(InventoryTransaction)
+    private transactions: Repository<InventoryTransaction>,
+  ) {}
+
+  // Product operations
+  createProduct(data: CreateProductInput) {
+    const product = this.products.create(data);
+    return this.products.save(product);
+  }
+
+  updateProduct(data: UpdateProductInput) {
+    return this.products.save(data);
+  }
+
+  removeProduct(id: number) {
+    return this.products.delete(id);
+  }
+
+  findAllProducts() {
+    return this.products.find();
+  }
+
+  findProduct(id: number) {
+    return this.products.findOneBy({ id });
+  }
+
+  // Inventory Transaction operations
+  createTransaction(data: CreateInventoryTransactionInput) {
+    const tx = this.transactions.create({
+      ...data,
+      productId: data.productId,
+    });
+    return this.transactions.save(tx);
+  }
+
+  updateTransaction(data: UpdateInventoryTransactionInput) {
+    return this.transactions.save(data);
+  }
+
+  removeTransaction(id: number) {
+    return this.transactions.delete(id);
+  }
+
+  findAllTransactions() {
+    return this.transactions.find({ relations: ['product'] });
+  }
+
+  findTransaction(id: number) {
+    return this.transactions.findOne({ where: { id }, relations: ['product'] });
+  }
+}

--- a/server/src/inventory/product.resolver.ts
+++ b/server/src/inventory/product.resolver.ts
@@ -1,0 +1,35 @@
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { InventoryService } from './inventory.service';
+import { Product } from './entities/product.entity';
+import { CreateProductInput } from './dto/create-product.input';
+import { UpdateProductInput } from './dto/update-product.input';
+
+@Resolver(() => Product)
+export class ProductResolver {
+  constructor(private readonly service: InventoryService) {}
+
+  @Mutation(() => Product)
+  createProduct(@Args('data') data: CreateProductInput) {
+    return this.service.createProduct(data);
+  }
+
+  @Mutation(() => Product)
+  updateProduct(@Args('data') data: UpdateProductInput) {
+    return this.service.updateProduct(data);
+  }
+
+  @Mutation(() => Boolean)
+  removeProduct(@Args('id', { type: () => Int }) id: number) {
+    return this.service.removeProduct(id).then(() => true);
+  }
+
+  @Query(() => [Product])
+  products() {
+    return this.service.findAllProducts();
+  }
+
+  @Query(() => Product, { nullable: true })
+  product(@Args('id', { type: () => Int }) id: number) {
+    return this.service.findProduct(id);
+  }
+}

--- a/src/utils/hasuraInventory.ts
+++ b/src/utils/hasuraInventory.ts
@@ -1,0 +1,68 @@
+export interface InventoryItem {
+  id: number;
+  product: {
+    id: number;
+    name: string;
+  };
+  quantity: number;
+  transaction_type: string;
+}
+
+const HASURA_URL = 'http://localhost:8080/v1/graphql';
+const ADMIN_SECRET = 'secretKey';
+
+async function graphql<T>(query: string, variables?: Record<string, any>): Promise<T> {
+  const res = await fetch(HASURA_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-hasura-admin-secret': ADMIN_SECRET,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(json.errors.map((e: any) => e.message).join(', '));
+  }
+  return json.data;
+}
+
+export async function fetchItems(): Promise<InventoryItem[]> {
+  const query = `
+    query {
+      inventory_transactions(order_by: {occurred_at: desc}) {
+        id
+        quantity
+        transaction_type
+        product {
+          id
+          name
+        }
+      }
+    }
+  `;
+  const data = await graphql<{ inventory_transactions: InventoryItem[] }>(query);
+  return data.inventory_transactions;
+}
+
+export async function addItem(productId: number, quantity: number, transactionType: string) {
+  const mutation = `
+    mutation InsertTx($productId: Int!, $quantity: Int!, $type: String!) {
+      insert_inventory_transactions_one(object: {product_id: $productId, quantity: $quantity, transaction_type: $type}) {
+        id
+      }
+    }
+  `;
+  await graphql(mutation, { productId, quantity, type: transactionType });
+}
+
+export async function updateItem(id: number, quantity: number) {
+  const mutation = `
+    mutation UpdateTx($id: Int!, $quantity: Int!) {
+      update_inventory_transactions_by_pk(pk_columns: {id: $id}, _set: {quantity: $quantity}) {
+        id
+      }
+    }
+  `;
+  await graphql(mutation, { id, quantity });
+}


### PR DESCRIPTION
## Summary
- add product and inventory transaction entities using code-first GraphQL decorators
- implement InventoryService with CRUD methods
- expose ProductResolver and InventoryTransactionResolver
- wire InventoryModule into AppModule
- add Hasura GraphQL utilities and refactor Inventory page to use them

## Testing
- `npm run build` in `server` *(fails: nest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684842c991ec832294ed11c93a108a4f