### PR TITLE
Secure inventory resolvers with JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This repository contains a basic Tauri + React application scaffolded with Vite 
 The `server` directory holds a NestJS API with GraphQL, PostgreSQL via TypeORM
 and simple JWT authentication.
 
+### Authentication
+
+All GraphQL mutations and queries require a valid JWT issued by the `login`
+mutation or one of the OAuth flows. Include the token in the `Authorization`
+header when communicating with the backend.
+
 Install dependencies and run the server:
 
 ```bash

--- a/server/src/auth/jwt-auth.guard.ts
+++ b/server/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,12 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+}
+

--- a/server/src/inventory/inventory-transaction.resolver.ts
+++ b/server/src/inventory/inventory-transaction.resolver.ts
@@ -1,34 +1,41 @@
 import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { InventoryService } from './inventory.service';
 import { InventoryTransaction } from './entities/inventory-transaction.entity';
 import { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.input';
 import { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.input';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Resolver(() => InventoryTransaction)
 export class InventoryTransactionResolver {
   constructor(private readonly service: InventoryService) {}
 
   @Mutation(() => InventoryTransaction)
+  @UseGuards(JwtAuthGuard)
   createTransaction(@Args('data') data: CreateInventoryTransactionInput) {
     return this.service.createTransaction(data);
   }
 
   @Mutation(() => InventoryTransaction)
+  @UseGuards(JwtAuthGuard)
   updateTransaction(@Args('data') data: UpdateInventoryTransactionInput) {
     return this.service.updateTransaction(data);
   }
 
   @Mutation(() => Boolean)
+  @UseGuards(JwtAuthGuard)
   removeTransaction(@Args('id', { type: () => Int }) id: number) {
     return this.service.removeTransaction(id).then(() => true);
   }
 
   @Query(() => [InventoryTransaction])
+  @UseGuards(JwtAuthGuard)
   transactions() {
     return this.service.findAllTransactions();
   }
 
   @Query(() => InventoryTransaction, { nullable: true })
+  @UseGuards(JwtAuthGuard)
   transaction(@Args('id', { type: () => Int }) id: number) {
     return this.service.findTransaction(id);
   }

--- a/server/src/inventory/product.resolver.ts
+++ b/server/src/inventory/product.resolver.ts
@@ -1,4 +1,6 @@
 import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { InventoryService } from './inventory.service';
 import { Product } from './entities/product.entity';
 import { CreateProductInput } from './dto/create-product.input';
@@ -9,26 +11,31 @@ export class ProductResolver {
   constructor(private readonly service: InventoryService) {}
 
   @Mutation(() => Product)
+  @UseGuards(JwtAuthGuard)
   createProduct(@Args('data') data: CreateProductInput) {
     return this.service.createProduct(data);
   }
 
   @Mutation(() => Product)
+  @UseGuards(JwtAuthGuard)
   updateProduct(@Args('data') data: UpdateProductInput) {
     return this.service.updateProduct(data);
   }
 
   @Mutation(() => Boolean)
+  @UseGuards(JwtAuthGuard)
   removeProduct(@Args('id', { type: () => Int }) id: number) {
     return this.service.removeProduct(id).then(() => true);
   }
 
   @Query(() => [Product])
+  @UseGuards(JwtAuthGuard)
   products() {
     return this.service.findAllProducts();
   }
 
   @Query(() => Product, { nullable: true })
+  @UseGuards(JwtAuthGuard)
   product(@Args('id', { type: () => Int }) id: number) {
     return this.service.findProduct(id);
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './index.css';
 import { sync } from './utils/inventoryDB';
 import { registerFCM } from './utils/firebaseClient';
+import { getToken } from './utils/authStore';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -16,9 +17,13 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 
 sync();
 registerFCM(async (token) => {
+  const jwt = await getToken();
   await fetch('http://localhost:3001/graphql', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
     body: JSON.stringify({
       query: 'mutation Register($token: String!) { registerDeviceToken(token: $token) }',
       variables: { token },


### PR DESCRIPTION
## Summary
- implement `JwtAuthGuard` for GraphQL
- protect inventory resolvers with the guard
- send stored JWT when registering FCM tokens
- document authentication requirement

## Testing
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684853e2ea588322854f1d79b0079cfc