### PR TITLE
Add Firebase service account initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,21 @@ docker-compose up -d
 ```
 
 Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT secret as the NestJS backend (`secretKey`).
+
+## Firebase Notifications
+
+The backend can send push notifications using Firebase Cloud Messaging. A service
+account JSON file is required for the Firebase Admin SDK. Create a new service
+account key from the Firebase console and download the JSON credentials. Supply
+the file path or JSON contents when starting the server:
+
+```bash
+# Path to JSON file
+FIREBASE_SERVICE_ACCOUNT_PATH=path/to/service-account.json npm run start:dev
+
+# Alternatively provide the JSON directly
+FIREBASE_SERVICE_ACCOUNT='{"project_id":"..."}' npm run start:dev
+```
+
+If neither variable is provided, the server falls back to Google application
+default credentials.

--- a/server/src/notifications/notifications.service.ts
+++ b/server/src/notifications/notifications.service.ts
@@ -6,14 +6,21 @@ export class NotificationsService implements OnModuleInit {
   private tokens = new Set<string>();
 
   onModuleInit() {
-    if (!admin.apps.length) {
-      try {
-        admin.initializeApp({
-          credential: admin.credential.applicationDefault(),
-        });
-      } catch (e) {
-        console.error('Firebase init failed', e);
+    if (admin.apps.length) return;
+    try {
+      const credsJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+      const credsPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+      let credential: admin.credential.Credential;
+      if (credsJson) {
+        credential = admin.credential.cert(JSON.parse(credsJson));
+      } else if (credsPath) {
+        credential = admin.credential.cert(credsPath);
+      } else {
+        credential = admin.credential.applicationDefault();
       }
+      admin.initializeApp({ credential });
+    } catch (e) {
+      console.error('Firebase init failed', e);
     }
   }
 


### PR DESCRIPTION
## Summary
- allow NotificationsService to use service account path or JSON
- document how to generate and supply Firebase credentials

## Testing
- `npx nest build` *(fails: could not determine executable to run)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853e2f1948322a20acac9b5e4255e