### PR TITLE
Add user registration and hashed auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,15 @@ docker-compose up -d
 ```
 
 Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT secret as the NestJS backend (`secretKey`).
+
+## User Creation
+
+Clients can create accounts using the `register` GraphQL mutation exposed by the NestJS server. Example mutation:
+
+```graphql
+mutation {
+  register(data: { username: "myuser", password: "secret" })
+}
+```
+
+The mutation returns a JWT which can be used for authenticated requests.

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
 import { AuthResolver } from './auth.resolver';
 import { GoogleStrategy } from './google.strategy';
 import { GitHubStrategy } from './github.strategy';
 import { AuthController } from './auth.controller';
+import { User } from '../user/user.entity';
 
 @Module({
   imports: [
     PassportModule,
+    TypeOrmModule.forFeature([User]),
     JwtModule.register({
       secret: 'secretKey',
       signOptions: { expiresIn: '60m' },

--- a/server/src/auth/auth.resolver.ts
+++ b/server/src/auth/auth.resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { LoginInput } from './dto/login.input';
+import { RegisterInput } from './dto/register.input';
 
 @Resolver()
 export class AuthResolver {
@@ -15,6 +16,15 @@ export class AuthResolver {
     if (!user) {
       throw new Error('Invalid credentials');
     }
+    return this.authService.login(user);
+  }
+
+  @Mutation(() => String)
+  async register(@Args('data') registerInput: RegisterInput) {
+    const user = await this.authService.registerUser(
+      registerInput.username,
+      registerInput.password,
+    );
     return this.authService.login(user);
   }
 }

--- a/server/src/auth/dto/register.input.ts
+++ b/server/src/auth/dto/register.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class RegisterInput {
+  @Field()
+  username: string;
+
+  @Field()
+  password: string;
+}


### PR DESCRIPTION
## Summary
- implement proper login validation using TypeORM and bcrypt
- add `registerUser` logic and GraphQL mutation
- wire `User` entity in `AuthModule`
- expose `RegisterInput` DTO
- document user creation in README

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853e357308322a1fede3fd7c38fed