### PR TITLE
Switch inventory API to JWT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,5 @@ services:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgres@db:5432/mydb
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_JWT_SECRET: '{"type":"HS256","key":"secretKey"}'
+      HASURA_GRAPHQL_ADMIN_SECRET: secretKey
 

--- a/src/utils/hasuraInventory.ts
+++ b/src/utils/hasuraInventory.ts
@@ -1,3 +1,5 @@
+import { getToken } from './authStore';
+
 export interface InventoryItem {
   id: number;
   product: {
@@ -9,14 +11,14 @@ export interface InventoryItem {
 }
 
 const HASURA_URL = 'http://localhost:8080/v1/graphql';
-const ADMIN_SECRET = 'secretKey';
 
 async function graphql<T>(query: string, variables?: Record<string, any>): Promise<T> {
+  const token = await getToken();
   const res = await fetch(HASURA_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-hasura-admin-secret': ADMIN_SECRET,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify({ query, variables }),
   });

--- a/src/utils/inventorySubscription.ts
+++ b/src/utils/inventorySubscription.ts
@@ -1,12 +1,14 @@
 import { createClient } from 'graphql-ws';
 import { InventoryItem } from './hasuraInventory';
+import { getToken } from './authStore';
 
 const client = createClient({
   url: 'ws://localhost:8080/v1/graphql',
-  connectionParams: {
-    headers: {
-      'x-hasura-admin-secret': 'secretKey',
-    },
+  connectionParams: async () => {
+    const token = await getToken();
+    return {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- authenticate Hasura requests using a saved JWT token
- subscribe to inventory updates using JWT-based headers
- support username/password login using the GraphQL `login` mutation and save the token
- secure Hasura container with an admin secret

## Testing
- `npm run build` *(fails: vite not found)*
- `cd server && npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853e40c1c8322a6f83efae4e4e0c2