### PR TITLE
Fix env config and persist notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ GITHUB_CLIENT_SECRET=your-github-client-secret
 
 # Firebase Admin SDK (Backend)
 GOOGLE_APPLICATION_CREDENTIALS=path/to/firebase-service-account.json
+SERVER_URL=http://localhost:3001
 
 # ===============================
 # Frontend (Vite) Configuration
@@ -36,3 +37,5 @@ VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
 VITE_FIREBASE_APP_ID=your-app-id
 VITE_FIREBASE_PUBLIC_VAPID_KEY=your-public-vapid-key
+VITE_BACKEND_URL=http://localhost:3001
+VITE_POUCHDB_REMOTE=http://localhost:5984/inventory

--- a/README.md
+++ b/README.md
@@ -67,17 +67,20 @@ Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT se
 
 ## Environment Variables
 
-Copy `.env.example` to `.env` and fill in the values for your environment. Key variables include:
+Copy `.env.example` to `.env` and fill in the values for your environment. Important keys include:
 
 - `JWT_SECRET` – secret used to sign JWT tokens
 - `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_NAME` – PostgreSQL connection settings
-- `VITE_HASURA_URL` – Hasura GraphQL endpoint used by the frontend
-- `VITE_HASURA_ADMIN_SECRET` – admin secret for Hasura
-- `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_MESSAGING_SENDER_ID`, `VITE_FIREBASE_APP_ID`, `VITE_FIREBASE_PUBLIC_VAPID_KEY` – Firebase configuration
+- `HASURA_ADMIN_SECRET` and `HASURA_GRAPHQL_JWT_SECRET`
+- OAuth credentials: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+- `GOOGLE_APPLICATION_CREDENTIALS` pointing to a Firebase service account JSON
+- `VITE_HASURA_URL` and `VITE_HASURA_ADMIN_SECRET`
+- Firebase client keys: `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_MESSAGING_SENDER_ID`, `VITE_FIREBASE_APP_ID`, `VITE_FIREBASE_PUBLIC_VAPID_KEY`
+- `VITE_BACKEND_URL` – base URL for the NestJS backend used by the frontend
+- `VITE_POUCHDB_REMOTE` – remote CouchDB URL for syncing
+- `SERVER_URL` – public URL of the backend used for OAuth callbacks
 
-
-
-Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT secret as the NestJS backend (`secretKey`).
+Hasura exposes a GraphQL API at `http://localhost:8080` and uses the same JWT secret as the NestJS backend (`JWT_SECRET`).
 
 
 ## User Creation
@@ -111,17 +114,6 @@ FIREBASE_SERVICE_ACCOUNT='{"project_id":"..."}' npm run start:dev
 If neither variable is provided, the server falls back to Google application
 default credentials.
 
-
-## Environment Variables
-
-Copy `.env.example` to `.env` and adjust the values for your setup. Important keys include:
-
-- `JWT_SECRET` – secret used to sign JWT tokens
-- Database configuration: `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`
-- `HASURA_ADMIN_SECRET` and `HASURA_GRAPHQL_JWT_SECRET`
-- OAuth credentials: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
-- Firebase client keys: `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_MESSAGING_SENDER_ID`, `FIREBASE_APP_ID`, `VAPID_PUBLIC_KEY`
-- `GOOGLE_APPLICATION_CREDENTIALS` pointing to a Firebase service account JSON
 
 ## Troubleshooting
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -27,3 +27,9 @@ CREATE TABLE IF NOT EXISTS inventory_transactions (
   occurred_at TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS device_tokens (
+  id SERIAL PRIMARY KEY,
+  token TEXT UNIQUE NOT NULL,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+);
+

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,7 +9,10 @@ import { User } from './user/user.entity';
 import { InventoryModule } from './inventory/inventory.module';
 import { Product } from './inventory/entities/product.entity';
 import { InventoryTransaction } from './inventory/entities/inventory-transaction.entity';
+import { Location } from './location/location.entity';
+import { LocationModule } from './location/location.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { DeviceToken } from './notifications/entities/device-token.entity';
 
 @Module({
   imports: [
@@ -24,13 +27,14 @@ import { NotificationsModule } from './notifications/notifications.module';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
-      entities: [User, Product, InventoryTransaction],
+      entities: [User, Product, InventoryTransaction, Location, DeviceToken],
       synchronize: true,
     }),
     AuthModule,
     InventoryModule,
+    LocationModule,
     NotificationsModule,
-    TypeOrmModule.forFeature([User, Product, InventoryTransaction]),
+    TypeOrmModule.forFeature([User, Product, InventoryTransaction, Location, DeviceToken]),
   ],
   providers: [AppResolver],
 })

--- a/server/src/auth/github.strategy.ts
+++ b/server/src/auth/github.strategy.ts
@@ -8,7 +8,7 @@ export class GitHubStrategy extends PassportStrategy(Strategy, 'github') {
     super({
       clientID: process.env.GITHUB_CLIENT_ID || 'GITHUB_CLIENT_ID',
       clientSecret: process.env.GITHUB_CLIENT_SECRET || 'GITHUB_CLIENT_SECRET',
-      callbackURL: 'http://localhost:3001/auth/github/redirect',
+      callbackURL: `${process.env.SERVER_URL || 'http://localhost:3001'}/auth/github/redirect`,
       scope: ['user:email'],
     });
   }

--- a/server/src/auth/google.strategy.ts
+++ b/server/src/auth/google.strategy.ts
@@ -8,7 +8,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     super({
       clientID: process.env.GOOGLE_CLIENT_ID || 'GOOGLE_CLIENT_ID',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'GOOGLE_CLIENT_SECRET',
-      callbackURL: 'http://localhost:3001/auth/google/redirect',
+      callbackURL: `${process.env.SERVER_URL || 'http://localhost:3001'}/auth/google/redirect`,
       scope: ['email', 'profile'],
     });
   }

--- a/server/src/inventory/dto/create-inventory-transaction.input.ts
+++ b/server/src/inventory/dto/create-inventory-transaction.input.ts
@@ -6,6 +6,12 @@ export class CreateInventoryTransactionInput {
   productId: number;
 
   @Field(() => Int)
+  locationId: number;
+
+  @Field(() => Int, { nullable: true })
+  userId?: number;
+
+  @Field(() => Int)
   quantity: number;
 
   @Field()

--- a/server/src/inventory/entities/inventory-transaction.entity.ts
+++ b/server/src/inventory/entities/inventory-transaction.entity.ts
@@ -1,6 +1,8 @@
 import { Field, ObjectType, Int } from '@nestjs/graphql';
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Product } from './product.entity';
+import { Location } from '../../location/location.entity';
+import { User } from '../../user/user.entity';
 
 @ObjectType()
 @Entity({ name: 'inventory_transactions' })
@@ -12,6 +14,14 @@ export class InventoryTransaction {
   @Field(() => Int)
   @Column()
   productId: number;
+
+  @Field(() => Int)
+  @Column()
+  locationId: number;
+
+  @Field(() => Int)
+  @Column()
+  userId: number;
 
   @Field(() => Int)
   @Column()
@@ -28,4 +38,12 @@ export class InventoryTransaction {
   @ManyToOne(() => Product)
   @JoinColumn({ name: 'product_id' })
   product: Product;
+
+  @ManyToOne(() => Location)
+  @JoinColumn({ name: 'location_id' })
+  location: Location;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
 }

--- a/server/src/inventory/inventory-transaction.resolver.ts
+++ b/server/src/inventory/inventory-transaction.resolver.ts
@@ -12,8 +12,11 @@ export class InventoryTransactionResolver {
 
   @Mutation(() => InventoryTransaction)
   @UseGuards(JwtAuthGuard)
-  createTransaction(@Args('data') data: CreateInventoryTransactionInput) {
-    return this.service.createTransaction(data);
+  createTransaction(
+    @Args('data') data: CreateInventoryTransactionInput,
+    @Context() ctx: any,
+  ) {
+    return this.service.createTransaction({ ...data, userId: ctx.req.user.userId });
   }
 
   @Mutation(() => InventoryTransaction)

--- a/server/src/inventory/inventory.service.ts
+++ b/server/src/inventory/inventory.service.ts
@@ -46,6 +46,8 @@ export class InventoryService {
     const tx = this.transactions.create({
       ...data,
       productId: data.productId,
+      locationId: data.locationId,
+      userId: data.userId,
     });
     const saved = await this.transactions.save(tx);
     const stock = await this.getCurrentStock(data.productId);

--- a/server/src/location/dto/create-location.input.ts
+++ b/server/src/location/dto/create-location.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class CreateLocationInput {
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  address?: string;
+}

--- a/server/src/location/dto/update-location.input.ts
+++ b/server/src/location/dto/update-location.input.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, Int, PartialType } from '@nestjs/graphql';
+import { CreateLocationInput } from './create-location.input';
+
+@InputType()
+export class UpdateLocationInput extends PartialType(CreateLocationInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/server/src/location/location.entity.ts
+++ b/server/src/location/location.entity.ts
@@ -1,0 +1,18 @@
+import { Field, ObjectType, Int } from '@nestjs/graphql';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@ObjectType()
+@Entity({ name: 'locations' })
+export class Location {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column()
+  name: string;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  address?: string;
+}

--- a/server/src/location/location.module.ts
+++ b/server/src/location/location.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Location } from './location.entity';
+import { LocationResolver } from './location.resolver';
+import { LocationService } from './location.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Location])],
+  providers: [LocationService, LocationResolver],
+  exports: [LocationService],
+})
+export class LocationModule {}

--- a/server/src/location/location.resolver.ts
+++ b/server/src/location/location.resolver.ts
@@ -1,0 +1,42 @@
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { LocationService } from './location.service';
+import { Location } from './location.entity';
+import { CreateLocationInput } from './dto/create-location.input';
+import { UpdateLocationInput } from './dto/update-location.input';
+
+@Resolver(() => Location)
+export class LocationResolver {
+  constructor(private readonly service: LocationService) {}
+
+  @Mutation(() => Location)
+  @UseGuards(JwtAuthGuard)
+  createLocation(@Args('data') data: CreateLocationInput) {
+    return this.service.create(data);
+  }
+
+  @Mutation(() => Location)
+  @UseGuards(JwtAuthGuard)
+  updateLocation(@Args('data') data: UpdateLocationInput) {
+    return this.service.update(data);
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(JwtAuthGuard)
+  removeLocation(@Args('id', { type: () => Int }) id: number) {
+    return this.service.remove(id).then(() => true);
+  }
+
+  @Query(() => [Location])
+  @UseGuards(JwtAuthGuard)
+  locations() {
+    return this.service.findAll();
+  }
+
+  @Query(() => Location, { nullable: true })
+  @UseGuards(JwtAuthGuard)
+  location(@Args('id', { type: () => Int }) id: number) {
+    return this.service.find(id);
+  }
+}

--- a/server/src/location/location.service.ts
+++ b/server/src/location/location.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Location } from './location.entity';
+import { CreateLocationInput } from './dto/create-location.input';
+import { UpdateLocationInput } from './dto/update-location.input';
+
+@Injectable()
+export class LocationService {
+  constructor(
+    @InjectRepository(Location)
+    private locations: Repository<Location>,
+  ) {}
+
+  create(data: CreateLocationInput) {
+    return this.locations.save(this.locations.create(data));
+  }
+
+  update(data: UpdateLocationInput) {
+    return this.locations.save(data);
+  }
+
+  remove(id: number) {
+    return this.locations.delete(id);
+  }
+
+  findAll() {
+    return this.locations.find();
+  }
+
+  find(id: number) {
+    return this.locations.findOneBy({ id });
+  }
+}

--- a/server/src/notifications/entities/device-token.entity.ts
+++ b/server/src/notifications/entities/device-token.entity.ts
@@ -1,0 +1,23 @@
+import { Field, ObjectType, Int } from '@nestjs/graphql';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from '../../user/user.entity';
+
+@ObjectType()
+@Entity({ name: 'device_tokens' })
+export class DeviceToken {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field()
+  @Column({ unique: true })
+  token: string;
+
+  @Field(() => Int, { nullable: true })
+  @Column({ nullable: true })
+  userId?: number;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'user_id' })
+  user?: User;
+}

--- a/server/src/notifications/notifications.module.ts
+++ b/server/src/notifications/notifications.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { NotificationsService } from './notifications.service';
 import { NotificationsResolver } from './notifications.resolver';
+import { DeviceToken } from './entities/device-token.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([DeviceToken])],
   providers: [NotificationsService, NotificationsResolver],
   exports: [NotificationsService],
 })

--- a/server/src/notifications/notifications.resolver.ts
+++ b/server/src/notifications/notifications.resolver.ts
@@ -1,4 +1,6 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { NotificationsService } from './notifications.service';
 
 @Resolver()
@@ -6,8 +8,10 @@ export class NotificationsResolver {
   constructor(private readonly notifications: NotificationsService) {}
 
   @Mutation(() => Boolean)
-  registerDeviceToken(@Args('token') token: string) {
-    this.notifications.registerToken(token);
+  @UseGuards(JwtAuthGuard)
+  registerDeviceToken(@Args('token') token: string, @Context() ctx: any) {
+    const userId = ctx.req.user?.userId;
+    this.notifications.registerToken(token, userId);
     return true;
   }
 }

--- a/server/src/notifications/notifications.service.ts
+++ b/server/src/notifications/notifications.service.ts
@@ -1,11 +1,19 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import * as admin from 'firebase-admin';
+import { DeviceToken } from './entities/device-token.entity';
 
 @Injectable()
 export class NotificationsService implements OnModuleInit {
   private tokens = new Set<string>();
 
-  onModuleInit() {
+  constructor(
+    @InjectRepository(DeviceToken)
+    private readonly tokensRepo: Repository<DeviceToken>,
+  ) {}
+
+  async onModuleInit() {
     if (admin.apps.length) return;
     try {
       const credsJson = process.env.FIREBASE_SERVICE_ACCOUNT;
@@ -19,13 +27,19 @@ export class NotificationsService implements OnModuleInit {
         credential = admin.credential.applicationDefault();
       }
       admin.initializeApp({ credential });
+      const stored = await this.tokensRepo.find();
+      stored.forEach((t) => this.tokens.add(t.token));
     } catch (e) {
       console.error('Firebase init failed', e);
     }
   }
 
-  registerToken(token: string) {
+  async registerToken(token: string, userId?: number) {
     this.tokens.add(token);
+    const exists = await this.tokensRepo.findOne({ where: { token } });
+    if (!exists) {
+      await this.tokensRepo.save(this.tokensRepo.create({ token, userId }));
+    }
   }
 
   async sendLowStockAlert(product: string, quantity: number) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 sync();
 registerFCM(async (token) => {
   const jwt = await getToken();
-  await fetch('http://localhost:3001/graphql', {
+  await fetch(`${import.meta.env.VITE_BACKEND_URL}/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,7 +16,7 @@ export default function Login() {
   }, []);
 
   const login = async () => {
-    const res = await fetch('http://localhost:3001/graphql', {
+    const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/graphql`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -38,7 +38,7 @@ export default function Login() {
     const y = window.top ? (window.outerHeight - h) / 2 : 0;
     const x = window.top ? (window.outerWidth - w) / 2 : 0;
     window.open(
-      `http://localhost:3001/auth/${provider}`,
+      `${import.meta.env.VITE_BACKEND_URL}/auth/${provider}`,
       'oauth',
       `width=${w},height=${h},left=${x},top=${y}`
     );

--- a/src/utils/inventoryDB.ts
+++ b/src/utils/inventoryDB.ts
@@ -7,7 +7,7 @@ export interface InventoryRecord {
 }
 
 const localDB = new PouchDB<InventoryRecord>('inventory');
-const remoteURL = 'http://localhost:5984/inventory';
+const remoteURL = import.meta.env.VITE_POUCHDB_REMOTE;
 let remoteDB: PouchDB.Database<InventoryRecord> | null = null;
 
 export async function addRecord(record: Omit<InventoryRecord, '_id'>) {


### PR DESCRIPTION
## Summary
- add Location entity, module and resolver
- align inventory transactions with DB schema
- persist notification device tokens and load them on startup
- make backend and CouchDB URLs configurable
- unify environment variable docs

## Testing
- `npm run build` *(fails: vite not found)*
- `cd server && npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684874e8a31083229ece9c30ebfa7c81