### PR TITLE
Add Jest tests for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ npm install
 npm run start:dev
 ```
 
+Run backend tests:
+
+```bash
+cd server
+npm test
+```
+
 ## Development
 
 Install dependencies and start the development server:

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  globals: {
+    'ts-jest': { tsconfig: 'tsconfig.json' }
+  }
+};

--- a/server/package.json
+++ b/server/package.json
@@ -5,16 +5,13 @@
   "scripts": {
     "start": "node dist/main.js",
     "start:dev": "nest start --watch",
-    "build": "nest build"
+    "build": "nest build",
+    "test": "node node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
-
     "@nestjs/graphql": "^12.2.2",
-
-   
-
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
@@ -36,6 +33,9 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/server/test/auth.service.spec.ts
+++ b/server/test/auth.service.spec.ts
@@ -1,0 +1,28 @@
+import { AuthService } from '../src/auth/auth.service';
+import type { JwtService } from '@nestjs/jwt';
+
+// simple mock JwtService
+const jwtService: JwtService = {
+  sign: jest.fn().mockReturnValue('signed-token'),
+} as any;
+
+describe('AuthService', () => {
+  const service = new AuthService(jwtService);
+
+  it('validates a user with correct credentials', async () => {
+    const result = await service.validateUser('test', 'test');
+    expect(result).toEqual({ id: 1, username: 'test' });
+  });
+
+  it('returns null for invalid credentials', async () => {
+    const result = await service.validateUser('test', 'wrong');
+    expect(result).toBeNull();
+  });
+
+  it('signs a token on login', async () => {
+    const user = { id: 1, username: 'test' };
+    const token = await service.login(user);
+    expect(jwtService.sign).toHaveBeenCalledWith({ username: 'test', sub: 1 });
+    expect(token).toBe('signed-token');
+  });
+});

--- a/server/test/inventory.service.spec.ts
+++ b/server/test/inventory.service.spec.ts
@@ -1,0 +1,46 @@
+import { InventoryService } from '../src/inventory/inventory.service';
+import { NotificationsService } from '../src/notifications/notifications.service';
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+  const productRepo = {
+    create: jest.fn((d) => d),
+    save: jest.fn(async (d) => Object.assign({ id: 1 }, d)),
+    delete: jest.fn(),
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+  } as any;
+
+  const txRepo = {
+    create: jest.fn((d) => d),
+    save: jest.fn(async (d) => d),
+    delete: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  } as any;
+
+  const notifications = {
+    sendLowStockAlert: jest.fn(),
+  } as unknown as NotificationsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new InventoryService(productRepo, txRepo, notifications);
+  });
+
+  it('creates a product', async () => {
+    await service.createProduct({ name: 'Widget' });
+    expect(productRepo.create).toHaveBeenCalledWith({ name: 'Widget' });
+    expect(productRepo.save).toHaveBeenCalled();
+  });
+
+  it('alerts when stock is low after transaction', async () => {
+    jest.spyOn(service as any, 'getCurrentStock').mockResolvedValue(3);
+    productRepo.findOneBy.mockResolvedValue({ id: 1, name: 'Widget' });
+
+    await service.createTransaction({ productId: 1, quantity: -2, transactionType: 'remove' });
+
+    expect(notifications.sendLowStockAlert).toHaveBeenCalledWith('Widget', 3);
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,8 +11,23 @@
     "outDir": "dist",
     "skipLibCheck": true,
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "lib": [
+      "es2018",
+      "dom"
+    ],
+    "downlevelIteration": true,
+    "types": [
+      "node",
+      "jest"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- setup Jest with ts-jest in the server project
- create example unit tests for authentication and inventory services
- expose `npm test` script
- document how to run tests

## Testing
- `npm test --silent` *(fails: 0 tests run)*

------
https://chatgpt.com/codex/tasks/task_e_684853e2c8d8832299eb4513246f0cb0