### PR TITLE
Add environment variable example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# Example environment configuration
+
+# Secret key used to sign JWT tokens (required)
+JWT_SECRET=
+
+# PostgreSQL connection settings
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_NAME=mydb
+
+# OAuth credentials (required for Google/GitHub login)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Optional path to Google service account credentials
+GOOGLE_APPLICATION_CREDENTIALS=
+
+# Firebase client configuration (required for push notifications)
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_PUBLIC_VAPID_KEY=
+
+# Base URL for the backend used by the frontend
+VITE_BACKEND_URL=http://localhost:3001
+
+# Remote CouchDB URL for syncing (optional)
+VITE_POUCHDB_REMOTE=
+
+# Public URL of the backend used for OAuth callbacks
+SERVER_URL=http://localhost:3001
+
+# Alternative Firebase admin credentials (optional)
+FIREBASE_SERVICE_ACCOUNT_PATH=
+FIREBASE_SERVICE_ACCOUNT=


### PR DESCRIPTION
## Summary
- add example environment file documenting variables from the README

## Testing
- `npm install` within `server`
- `npm test` within `server` *(fails: missing create transaction field)*

------
https://chatgpt.com/codex/tasks/task_e_6851d679e4f0832286092b152432aea9