### PR TITLE
Make server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Install dependencies and run the server:
 ```bash
 cd server
 npm install
-
+# start the server on port 3001 by default
 npm run start:dev
+
+# or specify a custom port
+# PORT=4000 npm run start:dev
 ```
 
 Run backend tests:
@@ -81,6 +84,7 @@ Copy `.env.example` to `.env` and fill in the values for your environment. Impor
 - `VITE_BACKEND_URL` – base URL for the NestJS backend used by the frontend
 - `VITE_POUCHDB_REMOTE` – remote CouchDB URL for syncing
 - `SERVER_URL` – public URL of the backend used for OAuth callbacks
+- `PORT` – port number for the NestJS server (defaults to 3001)
 
 
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3001);
+  const port = parseInt(process.env.PORT || '3001', 10);
+  await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- allow NestJS server port to be overridden with `PORT`
- document setting `PORT` in README

## Testing
- `npm install` within `server`
- `npm test` *(fails: Cannot find module / TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851d67f908883229797b2aca5dc2855