### PR TITLE
Fix tests with repository mocks

### DIFF
--- a/server/test/auth.service.spec.ts
+++ b/server/test/auth.service.spec.ts
@@ -1,13 +1,28 @@
 import { AuthService } from '../src/auth/auth.service';
 import type { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
+import { User } from '../src/user/user.entity';
+import * as bcrypt from 'bcrypt';
 
 // simple mock JwtService
 const jwtService: JwtService = {
   sign: jest.fn().mockReturnValue('signed-token'),
 } as any;
 
+// mock Repository<User>
+const userRepo = {
+  findOne: jest.fn(),
+} as unknown as Repository<User>;
+
 describe('AuthService', () => {
-  const service = new AuthService(jwtService);
+  let service: AuthService;
+  const passwordHash = bcrypt.hashSync('test', 10);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userRepo.findOne = jest.fn().mockResolvedValue({ id: 1, username: 'test', password: passwordHash });
+    service = new AuthService(jwtService, userRepo);
+  });
 
   it('validates a user with correct credentials', async () => {
     const result = await service.validateUser('test', 'test');

--- a/server/test/inventory.service.spec.ts
+++ b/server/test/inventory.service.spec.ts
@@ -39,7 +39,7 @@ describe('InventoryService', () => {
     jest.spyOn(service as any, 'getCurrentStock').mockResolvedValue(3);
     productRepo.findOneBy.mockResolvedValue({ id: 1, name: 'Widget' });
 
-    await service.createTransaction({ productId: 1, quantity: -2, transactionType: 'remove' });
+    await service.createTransaction({ productId: 1, locationId: 1, quantity: -2, transactionType: 'remove' });
 
     expect(notifications.sendLowStockAlert).toHaveBeenCalledWith('Widget', 3);
   });


### PR DESCRIPTION
## Summary
- mock `Repository<User>` in `auth.service.spec.ts` and pass it to AuthService
- add `locationId` in inventory service test
- ensure tests run correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d688808c832290d13ddffbe941fb