### PR TITLE
Ensure OAuth JWT uses numeric user id

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
 
   async oauthLogin(user: any) {
     const payload = {
-      sub: user.email || user.username,
+      sub: user.id,
       ...user,
     };
     return this.jwtService.sign(payload);

--- a/server/test/auth.service.spec.ts
+++ b/server/test/auth.service.spec.ts
@@ -1,13 +1,26 @@
 import { AuthService } from '../src/auth/auth.service';
 import type { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
 
 // simple mock JwtService
 const jwtService: JwtService = {
   sign: jest.fn().mockReturnValue('signed-token'),
 } as any;
 
+// mock User repository
+const usersRepo = {
+  findOne: jest.fn(async ({ where: { username } }) => {
+    if (username === 'test') {
+      return { id: 1, username: 'test', password: 'hashed' };
+    }
+    return null;
+  }),
+} as any;
+
+jest.spyOn(bcrypt, 'compare').mockImplementation(async (pass: string) => pass === 'test');
+
 describe('AuthService', () => {
-  const service = new AuthService(jwtService);
+  const service = new AuthService(jwtService, usersRepo);
 
   it('validates a user with correct credentials', async () => {
     const result = await service.validateUser('test', 'test');

--- a/server/test/inventory.service.spec.ts
+++ b/server/test/inventory.service.spec.ts
@@ -39,7 +39,12 @@ describe('InventoryService', () => {
     jest.spyOn(service as any, 'getCurrentStock').mockResolvedValue(3);
     productRepo.findOneBy.mockResolvedValue({ id: 1, name: 'Widget' });
 
-    await service.createTransaction({ productId: 1, quantity: -2, transactionType: 'remove' });
+    await service.createTransaction({
+      productId: 1,
+      locationId: 1,
+      quantity: -2,
+      transactionType: 'remove',
+    });
 
     expect(notifications.sendLowStockAlert).toHaveBeenCalledWith('Widget', 3);
   });


### PR DESCRIPTION
## Summary
- always sign JWT using `user.id` for OAuth logins
- mock repository and bcrypt in `AuthService` unit test
- fix inventory test input to include `locationId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d68773bc8322930d185795130fbb