### PR TITLE
Fix workflow build command

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Build
+    - name: Install and Test
       run: |
         npm install
-        grunt
+        npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "npm --prefix server install && npm --prefix server test"
   },
   "dependencies": {
     "@tauri-apps/plugin-store": "^2.2.0",


### PR DESCRIPTION
## Summary
- use npm install and test in CI workflow instead of grunt
- add root test script to run server tests

## Testing
- `npm test` *(fails: Argument of type ... missing required property)*

------
https://chatgpt.com/codex/tasks/task_e_6851d6834c2083229e872f8499e5416e