### PR TITLE
Implement basic error code handling

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
+import { GraphQLError } from 'graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { join } from 'path';
@@ -16,6 +17,7 @@ import { PriceHistory } from './inventory/entities/price-history.entity';
 import { NotificationsModule } from './notifications/notifications.module';
 import { ReportsModule } from './reports/reports.module';
 import { DeviceToken } from './notifications/entities/device-token.entity';
+import { AppError, ErrorCode } from './errors/error-codes';
 
 @Module({
   imports: [
@@ -23,6 +25,13 @@ import { DeviceToken } from './notifications/entities/device-token.entity';
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       autoSchemaFile: join(process.cwd(), 'schema.gql'),
+      formatError: (error: GraphQLError) => {
+        const original: any = error.originalError;
+        if (original instanceof AppError) {
+          return { message: original.message, extensions: { code: original.code } };
+        }
+        return { message: error.message, extensions: { code: ErrorCode.UNKNOWN } };
+      },
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/server/src/auth/auth.resolver.ts
+++ b/server/src/auth/auth.resolver.ts
@@ -2,6 +2,7 @@ import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { LoginInput } from './dto/login.input';
 import { RegisterInput } from './dto/register.input';
+import { AppError, ErrorCode } from '../errors/error-codes';
 
 @Resolver()
 export class AuthResolver {
@@ -14,7 +15,7 @@ export class AuthResolver {
       loginInput.password,
     );
     if (!user) {
-      throw new Error('Invalid credentials');
+      throw new AppError(ErrorCode.AUTH_INVALID, 'Invalid credentials');
     }
     return this.authService.login(user);
   }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { User } from '../user/user.entity';
+import { AppError, ErrorCode } from '../errors/error-codes';
 
 @Injectable()
 export class AuthService {

--- a/server/src/errors/error-codes.ts
+++ b/server/src/errors/error-codes.ts
@@ -1,0 +1,15 @@
+export enum ErrorCode {
+  UNKNOWN = 'E0000',
+  NETWORK = 'E0001',
+  VALIDATION = 'E1000',
+  AUTH_INVALID = 'E2000',
+  AUTH_REQUIRED = 'E2001',
+  NOT_FOUND = 'E3000',
+  DB_ERROR = 'E4000',
+}
+
+export class AppError extends Error {
+  constructor(public code: ErrorCode, message: string) {
+    super(message);
+  }
+}

--- a/server/src/inventory/inventory.service.ts
+++ b/server/src/inventory/inventory.service.ts
@@ -14,6 +14,7 @@ import { CreateInventoryTransactionInput } from './dto/create-inventory-transact
 import { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.input';
 import { NotificationsService } from '../notifications/notifications.service';
 import { PriceHistoryService } from './price-history.service';
+import { AppError, ErrorCode } from '../errors/error-codes';
 
 @Injectable()
 export class InventoryService {
@@ -71,7 +72,7 @@ export class InventoryService {
     const currentProduct = await this.products.findOneBy({ id: data.id });
     
     if (!currentProduct) {
-      throw new Error('Product not found');
+      throw new AppError(ErrorCode.NOT_FOUND, 'Product not found');
     }
 
     // Track price changes

--- a/server/test/inventory.service.spec.ts
+++ b/server/test/inventory.service.spec.ts
@@ -39,9 +39,13 @@ describe('InventoryService', () => {
     sendLowStockAlert: jest.fn(),
   } as unknown as NotificationsService;
 
+  const priceHistoryService = {
+    trackPriceChange: jest.fn(),
+  } as any;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new InventoryService(productRepo, categoryRepo, productNoteRepo, txRepo, notifications);
+    service = new InventoryService(productRepo, categoryRepo, productNoteRepo, txRepo, notifications, priceHistoryService);
   });
 
   it('creates a product', async () => {

--- a/src/components/ErrorProvider.tsx
+++ b/src/components/ErrorProvider.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState } from 'react';
+import Snackbar from './Snackbar';
+
+interface ErrorContextValue {
+  showError: (message: string) => void;
+}
+
+const ErrorContext = createContext<ErrorContextValue>({ showError: () => {} });
+
+export function ErrorProvider({ children }: { children: React.ReactNode }) {
+  const [message, setMessage] = useState('');
+  return (
+    <ErrorContext.Provider value={{ showError: (msg) => setMessage(msg) }}>
+      {children}
+      {message && <Snackbar message={message} onClose={() => setMessage('')} />}
+    </ErrorContext.Provider>
+  );
+}
+
+export const useError = () => useContext(ErrorContext);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,11 +5,14 @@ import App from './App';
 import './index.css';
 import { registerFCM } from './utils/firebaseClient';
 import { getToken } from './utils/authStore';
+import { ErrorProvider } from './components/ErrorProvider';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ErrorProvider>
+        <App />
+      </ErrorProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { fetchInventorySummary, InventorySummary } from '../utils/inventoryApi';
+import { fetchInventorySummary, InventorySummary, ApiError } from '../utils/inventoryApi';
+import { useError } from '../components/ErrorProvider';
+import { getErrorMessage, ErrorCode } from '../utils/errorCodes';
 
 export default function Dashboard() {
   const [summary, setSummary] = useState<InventorySummary>({
@@ -16,6 +18,7 @@ export default function Dashboard() {
     recentTransactions: 0,
     lowStockCount: 0,
   });
+  const { showError } = useError();
 
   // Animate counter values
   useEffect(() => {
@@ -56,8 +59,10 @@ export default function Dashboard() {
       setLoading(true);
       const data = await fetchInventorySummary();
       setSummary(data);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to load dashboard data:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     } finally {
       setLoading(false);
     }

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -1,18 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import QuickActions from '../components/QuickActions';
-import { 
-  fetchItems, 
+import {
+  fetchItems,
   fetchProducts,
   fetchCategories,
-  addItem, 
-  updateItem, 
+  addItem,
+  updateItem,
   createProduct,
   createCategory,
   InventoryItem,
   Product,
-  Category
+  Category,
+  ApiError
 } from '../utils/inventoryApi';
+import { useError } from '../components/ErrorProvider';
+import { getErrorMessage, ErrorCode } from '../utils/errorCodes';
 
 type TabType = 'overview' | 'transactions' | 'products' | 'categories';
 
@@ -55,6 +58,7 @@ export default function Inventory() {
   });
 
   const [editing, setEditing] = useState<{ [id: number]: { quantity: number; notes: string } }>({});
+  const { showError } = useError();
 
   const loadData = async () => {
     try {
@@ -68,8 +72,10 @@ export default function Inventory() {
       setTransactions(txData);
       setProducts(productData);
       setCategories(categoryData);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to load inventory data:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     } finally {
       setLoading(false);
     }
@@ -109,8 +115,10 @@ export default function Inventory() {
       setTransactionForm({ productId: 0, quantity: 0, transactionType: 'add', notes: '' });
       setShowAddTransaction(false);
       await loadData();
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to add transaction:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     }
   };
 
@@ -124,8 +132,10 @@ export default function Inventory() {
       setProductForm({ name: '', description: '', sku: '', unit: '', categoryId: 0, restockThreshold: 5 });
       setShowAddProduct(false);
       await loadData();
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to add product:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     }
   };
 
@@ -136,8 +146,10 @@ export default function Inventory() {
       setCategoryForm({ name: '', description: '' });
       setShowAddCategory(false);
       await loadData();
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to add category:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     }
   };
 
@@ -152,8 +164,10 @@ export default function Inventory() {
         return newEditing;
       });
       await loadData();
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to update transaction:', error);
+      const code = error instanceof ApiError ? error.code : ErrorCode.UNKNOWN;
+      showError(getErrorMessage(code));
     }
   };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { saveToken } from '../utils/authStore';
+import { useError } from '../components/ErrorProvider';
+import { getErrorMessage, ErrorCode } from '../utils/errorCodes';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -7,6 +9,7 @@ export default function Login() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [isRegister, setIsRegister] = useState(false);
+  const { showError } = useError();
 
   useEffect(() => {
     const handler = async (e: MessageEvent) => {
@@ -56,6 +59,8 @@ export default function Login() {
       console.log('Response data:', json);
       
       if (json.errors) {
+        const code = json.errors[0].extensions?.code || ErrorCode.UNKNOWN;
+        showError(getErrorMessage(code));
         setError(json.errors[0].message);
         return;
       }
@@ -65,10 +70,13 @@ export default function Login() {
         await saveToken(token);
         window.location.assign('/dashboard');
       } else {
+        showError(getErrorMessage(ErrorCode.AUTH_INVALID));
         setError('Authentication failed');
       }
-    } catch (err) {
+    } catch (err: any) {
       console.error('Network error details:', err);
+      const code = err?.code || ErrorCode.NETWORK;
+      showError(getErrorMessage(code));
       setError(`Network error: ${err instanceof Error ? err.message : 'Please try again.'}`);
     } finally {
       setIsLoading(false);

--- a/src/utils/errorCodes.ts
+++ b/src/utils/errorCodes.ts
@@ -1,0 +1,22 @@
+export enum ErrorCode {
+  UNKNOWN = 'E0000',
+  NETWORK = 'E0001',
+  VALIDATION = 'E1000',
+  AUTH_INVALID = 'E2000',
+  AUTH_REQUIRED = 'E2001',
+  NOT_FOUND = 'E3000',
+  DB_ERROR = 'E4000',
+}
+
+const messages: Record<string, string> = {
+  [ErrorCode.NETWORK]: 'Network error, please try again later.',
+  [ErrorCode.AUTH_INVALID]: 'Invalid credentials. (Code: E2000)',
+  [ErrorCode.AUTH_REQUIRED]: 'Authentication required. (Code: E2001)',
+  [ErrorCode.NOT_FOUND]: 'Item not found. (Code: E3000)',
+  [ErrorCode.DB_ERROR]: 'Server error. (Code: E4000)',
+  [ErrorCode.VALIDATION]: 'Invalid data provided. (Code: E1000)',
+};
+
+export function getErrorMessage(code: string): string {
+  return messages[code] || `Unexpected error occurred. (Code: ${code})`;
+}

--- a/src/utils/inventoryApi.ts
+++ b/src/utils/inventoryApi.ts
@@ -1,4 +1,11 @@
 import { getToken } from './authStore';
+import { ErrorCode } from './errorCodes';
+
+export class ApiError extends Error {
+  constructor(public code: string, message: string) {
+    super(message);
+  }
+}
 
 export interface InventoryItem {
   id: number;
@@ -62,17 +69,24 @@ const API_URL = `${import.meta.env.VITE_BACKEND_URL}/graphql`;
 
 async function graphql<T>(query: string, variables?: Record<string, any>): Promise<T> {
   const token = await getToken();
-  const res = await fetch(API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+  } catch (_) {
+    throw new ApiError(ErrorCode.NETWORK, 'Network error');
+  }
   const json = await res.json();
-  if (json.errors) {
-    throw new Error(json.errors.map((e: any) => e.message).join(', '));
+  if (json.errors && json.errors.length > 0) {
+    const first = json.errors[0];
+    const code = first.extensions?.code || ErrorCode.UNKNOWN;
+    throw new ApiError(code, first.message);
   }
   return json.data;
 }


### PR DESCRIPTION
## Summary
- add `AppError` and `ErrorCode` enum on server
- format GraphQL errors to return codes
- throw coded errors for auth and inventory operations
- provide `ErrorProvider` and error code utilities on frontend
- surface error messages in Dashboard, Inventory, and Login pages
- update API layer for typed `ApiError`
- adjust inventory service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8af74eec8322973dcfd675b179b7